### PR TITLE
#118 에디터 툴 관련 오류 해결 및 개선

### DIFF
--- a/Source/ArcanePunkEditorTools/Public/SkillTest/FSkillEditorTool.h
+++ b/Source/ArcanePunkEditorTools/Public/SkillTest/FSkillEditorTool.h
@@ -37,5 +37,6 @@ private:
 	TMap<ESkillKey, TSharedPtr<SComboBox<TSharedPtr<FName>>>> SkillDropdown;
 	TMap<ESkillKey, TSharedPtr<FName>> SelectedSkills;
 	TSharedPtr<SCheckBox> EnableToolCheckBox;
+	TSharedPtr<SButton> EquipButton;
 };
 


### PR DESCRIPTION
****
### 업데이트 사항
- Skill Editor 툴의 버튼 활성화와 비활성화가 제대로 이루어지고 있지 않던 오류 해결
- 스킬 드롭다운의 값들이 게임 실행 시에 다시 설정될 수 있도록 개선

*****
### 담당자
- (클라) : @jiy12345 

